### PR TITLE
Make gitleaks version detection more resilient

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,9 +81,26 @@ runs:
         platform=$(echo $arch | tr '[:upper:]' '[:lower:]' )
         platform="${platform//aarch64/arm64}"
         platform="${platform//x86_64/x64}"
-        version_tag="$(curl --retry 5 -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .name)"
+
+        max_attempts=5
+        attempt=0
+        while [[ $attempt -lt $max_attempts ]]; do
+            version_tag="$(curl --retry 5 -s -f https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .name)"
+            version="${version_tag#v}"
+            if [[ -n "$version" ]]; then
+                break
+            fi
+            attempt=$((attempt + 1))
+            echo "::warning::Attempt $attempt failed to fetch version, retrying in 60 seconds..." >&2
+            sleep 60
+        done
+
+        if [[ -z "$version" ]]; then
+            echo "::error::Failed to fetch Gitleaks version after $max_attempts attempts." >&2
+            exit 1
+        fi
         echo "platform=$platform" >> $GITHUB_OUTPUT
-        echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+        echo "version=${version}" >> $GITHUB_OUTPUT
 
     - name: Install gitleaks (macos)
       if: runner.os == 'macOS'


### PR DESCRIPTION
Should a avoid issue seen on https://github.com/ansible/ansible-lint/actions/runs/15823147844/job/44596839162?pr=4659
