### PR TITLE
Correct logic for version checks and expand fallback methods

### DIFF
--- a/scripts/ensure-gitleaks.sh
+++ b/scripts/ensure-gitleaks.sh
@@ -5,13 +5,16 @@ set -euo pipefail
 DEBUG="${1:-false}"
 MAX_ATTEMPTS=10
 
+# Global variables used across platform-specific installation logic
+attempt=0
+version=""
 
 if [[ "${DEBUG}" = "true" ]]
 then
   set -x
 fi
 
-gitleaks_cmd=$(command -v gitleaks ~/.local/bin/gitleaks | head -1 || true)
+gitleaks_cmd=$(command -v gitleaks 2>/dev/null || find ~/.local/bin -name gitleaks -executable 2>/dev/null | head -1 || true)
 arch="$(uname)_$(uname -m)"
 platform=$(echo "$arch" | tr '[:upper:]' '[:lower:]' )
 if [[ "$platform" =~ mingw.* || "$platform" =~ cygwin.* || "$platform" =~ msys.* ]]; then
@@ -31,29 +34,72 @@ else
 fi
 
 if [[ -n "$gitleaks_cmd" ]]; then
-    version="$(gitleaks --version 2>/dev/null || true)"
+    version="$($gitleaks_cmd --version 2>/dev/null || true)"
     if [[ -n "$version" ]]; then
         echo "::notice::Detected ${gitleaks_cmd} version ${version} on ${platform}."
         exit 0
+    else
+        echo "::warning::Found gitleaks at ${gitleaks_cmd} but version check failed. Will attempt to reinstall."
+        # Clear gitleaks_cmd to force reinstallation
+        gitleaks_cmd=""
     fi
-else
+fi
+
+# Installation logic (runs if no working gitleaks found)
+if [[ -z "$gitleaks_cmd" ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         brew install gitleaks
         gitleaks_cmd=$(command -v gitleaks)
-        version="$(gitleaks --version || true)"
+        version="$($gitleaks_cmd --version || true)"
     elif [[ "$OSTYPE" == "linux"* || "$OSTYPE" == "msys"* ]]; then
-        attempt=0
-        while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
-            # Not using curl+jq because jq is not available on Windows github runners
-            version_tag="$(gh release view --repo gitleaks/gitleaks --json tagName -q .tagName)"
-            version="${version_tag#v}"
-            if [[ -n "$version" ]]; then
-                break
+        # Function to fetch version using gh CLI
+        fetch_version_with_gh() {
+            if command -v gh >/dev/null 2>&1; then
+                local version_tag
+                version_tag="$(gh release view --repo gitleaks/gitleaks --json tagName -q .tagName 2>/dev/null || true)"
+                if [[ -n "$version_tag" ]]; then
+                    echo "${version_tag#v}"
+                    return 0
+                fi
             fi
+            return 1
+        }
+        
+        # Function to fetch version using curl as fallback
+        fetch_version_with_curl() {
+            local version_tag
+            version_tag="$(curl -s --fail --connect-timeout 10 --max-time 30 \
+                "https://api.github.com/repos/gitleaks/gitleaks/releases/latest" \
+                | grep -o '"tag_name": *"[^"]*"' \
+                | grep -o 'v[^"]*' || true)"
+            if [[ -n "$version_tag" ]]; then
+                echo "${version_tag#v}"
+                return 0
+            fi
+            return 1
+        }
+
+        while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
             attempt=$((attempt + 1))
-            delay=$((10 + attempt * 10))
-            echo "::warning::Attempt $attempt failed to fetch version, retrying in $delay seconds. stdout: ${version_tag}"
-            sleep $delay
+            echo "Attempt $attempt to fetch Gitleaks version..."
+            
+            # Try gh first, then curl as fallback
+            if version="$(fetch_version_with_gh)"; then
+                echo "::notice::Successfully fetched version $version using gh CLI"
+                break
+            elif version="$(fetch_version_with_curl)"; then
+                echo "::notice::Successfully fetched version $version using curl fallback"
+                break
+            else
+                if [[ $attempt -lt $MAX_ATTEMPTS ]]; then
+                    delay=$((10 + attempt * 5))
+                    echo "::warning::Attempt $attempt failed to fetch version. Retrying in $delay seconds..."
+                    sleep $delay
+                else
+                    echo "::error::Failed to fetch Gitleaks version after $MAX_ATTEMPTS attempts."
+                    exit 3
+                fi
+            fi
         done
         mkdir -p ~/.local/bin
         if [[ "$OSTYPE" == "msys"* ]]; then


### PR DESCRIPTION
Fixes version checking logic that would skip to exit if version wasn't found. This was done by using `gitleaks_cmd` in the version check instead of just `gitleaks`.

Adds a fallback mechanism for gitleaks installation through curl in addition to gh CLI. This is needed for our WSL runner. 

